### PR TITLE
I cannot abide scripts as aliases

### DIFF
--- a/gitconfig.local
+++ b/gitconfig.local
@@ -1,2 +1,2 @@
 [alias]
-  branches = "!for k in `git branch -r| grep -v HEAD | awk '{print $1}'`;do echo `git show --pretty=format:\"%Cgreen%ci %Cblue%cr %Cred%cn %Creset\" $k|head -n 1`\\\t$k;done|sort -r"
+  branches = for-each-ref --sort=-committerdate --format=\"%(color:green)%(authordate) %(color:blue)%(authordate:relative) %(color:red)%(authorname) %(color:white)%(color:bold)%(refname)\" refs/heads


### PR DESCRIPTION
So I fixed this for you.

If it looks like the sorting is off, it's because I'm displaying author
dates (the time the commit will show) and sorting by comitter date (the
commit time), which is a compromise between showing when GitHub and Git
will show something happened and "staleness".
